### PR TITLE
Trigger mode should only restart (stop and then start) the camera

### DIFF
--- a/src/ensenso_driver.cpp
+++ b/src/ensenso_driver.cpp
@@ -350,8 +350,10 @@ class EnsensoDriver
       {
         trigger_mode_ = trigger_mode;
         if (was_running)
+        {
           ensenso_ptr_->stop();
           ensenso_ptr_->start();
+        }
       }
       return true;
     }

--- a/src/ensenso_driver.cpp
+++ b/src/ensenso_driver.cpp
@@ -312,41 +312,47 @@ class EnsensoDriver
 
     bool configureStreaming(const bool cloud, const bool images, const int trigger_mode)
     {
-      if ((is_streaming_cloud_ == cloud)
-              && (is_streaming_images_ == images)
-              && (trigger_mode_ == trigger_mode) ) return true;  // Nothing to be done here
-      is_streaming_cloud_ = cloud;
-      is_streaming_images_ = images;
-      trigger_mode_ = trigger_mode;
       bool was_running = ensenso_ptr_->isRunning();
-      if (was_running)
-        ensenso_ptr_->stop();
-      // Disconnect previous connection
-      connection_.disconnect();
-      // Connect new signals
-      if (cloud && images)
+      if ((is_streaming_cloud_ != cloud) || (is_streaming_images_ != images))
       {
-        boost::function<void(
-          const boost::shared_ptr<PointCloudXYZ>&,
-          const boost::shared_ptr<PairOfImages>&,
-          const boost::shared_ptr<PairOfImages>&)> f = boost::bind (&EnsensoDriver::grabberCallback, this, _1, _2, _3);
-        connection_ = ensenso_ptr_->registerCallback(f);
+        is_streaming_cloud_ = cloud;
+        is_streaming_images_ = images;
+        if (was_running)
+          ensenso_ptr_->stop();
+        // Disconnect previous connection
+        connection_.disconnect();
+        // Connect new signals
+        if (cloud && images)
+        {
+          boost::function<void(
+            const boost::shared_ptr<PointCloudXYZ>&,
+            const boost::shared_ptr<PairOfImages>&,
+            const boost::shared_ptr<PairOfImages>&)> f = boost::bind (&EnsensoDriver::grabberCallback, this, _1, _2, _3);
+          connection_ = ensenso_ptr_->registerCallback(f);
+        }
+        else if (images)
+        {
+          boost::function<void(
+            const boost::shared_ptr<PairOfImages>&,
+            const boost::shared_ptr<PairOfImages>&)> f = boost::bind (&EnsensoDriver::grabberCallback, this, _1, _2);
+          connection_ = ensenso_ptr_->registerCallback(f);
+        }
+        else if (cloud)
+        {
+          boost::function<void(
+              const boost::shared_ptr<PointCloudXYZ>&)> f = boost::bind (&EnsensoDriver::grabberCallback, this, _1);
+          connection_ = ensenso_ptr_->registerCallback(f);
+        }
+        if (was_running)
+          ensenso_ptr_->start();
       }
-      else if (images)
+      else if (trigger_mode_ != trigger_mode)
       {
-        boost::function<void(
-          const boost::shared_ptr<PairOfImages>&,
-          const boost::shared_ptr<PairOfImages>&)> f = boost::bind (&EnsensoDriver::grabberCallback, this, _1, _2);
-        connection_ = ensenso_ptr_->registerCallback(f);
+        trigger_mode_ = trigger_mode;
+        if (was_running)
+          ensenso_ptr_->stop();
+          ensenso_ptr_->start();
       }
-      else if (cloud)
-      {
-        boost::function<void(
-            const boost::shared_ptr<PointCloudXYZ>&)> f = boost::bind (&EnsensoDriver::grabberCallback, this, _1);
-        connection_ = ensenso_ptr_->registerCallback(f);
-      }
-      if (was_running)
-        ensenso_ptr_->start();
       return true;
     }
 


### PR DESCRIPTION
@ytakio sorry for the late reply. Here is my suggestion for handling the changes in trigger mode.
This makes sure that when you _only_ change the trigger mode, the camera is _only_ restarted (stop-start).
The behavior of the `Cloud` and `Images` parameters remains the same.